### PR TITLE
'Version 1.1.0 of the DynamoDB Lock Client'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>dynamodb-lock-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     <name>Amazon DynamoDB Lock Client</name>
     <url>https://github.com/awslabs/dynamodb-lock-client</url>
     <description>The Amazon DynamoDB Lock Client is a general purpose distributed locking library built on DynamoDB.</description>
     <scm>
         <url>git@github.com:awslabs/dynamodb-lock-client.git</url>
-        <tag>1.0.0</tag>
+        <tag>1.1.0</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,35 +17,35 @@
         <dynamodb-local.port>4567</dynamodb-local.port>
         <dynamodb-local.endpoint>http://localhost:${dynamodb-local.port}</dynamodb-local.endpoint>
         <jdk.version>1.8</jdk.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aws.java.sdk.version>1.11.160</aws.java.sdk.version>
-        <dependency.plugin.version>3.0.0</dependency.plugin.version>
-        <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
-        <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
-        <maven.surefire.version>2.20</maven.surefire.version>
-        <maven.failsafe.version>2.20</maven.failsafe.version>
-        <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
-        <exec.maven.plugin.version>1.6.0</exec.maven.plugin.version>
+
+        <aws.java.sdk.version>1.11.475</aws.java.sdk.version>
+        <dependency.plugin.version>3.1.1</dependency.plugin.version>
+        <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
+        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+        <maven.surefire.version>2.22.1</maven.surefire.version>
+        <maven.failsafe.version>2.22.1</maven.failsafe.version>
+        <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
         <download.maven.plugin.version>1.2.1</download.maven.plugin.version>
-        <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
+        <build.helper.maven.plugin.version>3.0.0</build.helper.maven.plugin.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.4</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.2</jacoco.version>
+        <commons-logging.version>1.2</commons-logging.version>
+        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
+        <junit.version>4.12</junit.version>
+
         <build.profile.id>dev</build.profile.id>
         <jacoco.it.execution.data.file>${project.build.directory}/coverage-reports/jacoco-it.exec</jacoco.it.execution.data.file>
         <jacoco.ut.execution.data.file>${project.build.directory}/coverage-reports/jacoco-ut.exec</jacoco.ut.execution.data.file>
-        <commons-logging.version>1.2</commons-logging.version>
-        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
-        <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
         <jacoco-aggregate-destFile>${project.build.directory}/coverage-reports/aggregate.exec</jacoco-aggregate-destFile>
-        <junit.version>4.12</junit.version>
-        <integration-test.category>*/BasicLockClientTests.java,*/GetAllLocksTests.java</integration-test.category>
+        <integration-test.category>*/BasicLockClientTests.java,*/GetAllLocksTests.java,*/ConsistentLockDataStressTest.java</integration-test.category>
     </properties>
     <developers>
         <developer>
             <name>Alexander Patrikalakis</name>
-            <email>amcp@amazon.co.jp</email>
+            <email>amcpatrikalakis@gmail.com</email>
             <url>https://www.linkedin.com/in/amcpatrix/en</url>
         </developer>
         <developer>
@@ -57,6 +57,21 @@
             <name>David Yanacek</name>
             <email>dyanacek@amazon.com</email>
             <url>https://www.linkedin.com/in/david-yanacek-5927362/</url>
+        </developer>
+        <developer>
+            <name>Mukti Ranjan Sahoo</name>
+            <email>mukti@amazon.com</email>
+            <url>https://www.linkedin.com/in/mukti-ranjan-sahoo-50051098/</url>
+        </developer>
+        <developer>
+            <name>Amey Jain</name>
+            <email>jainame@amazon.com</email>
+            <url>https://www.linkedin.com/in/ameyjain/</url>
+        </developer>
+        <developer>
+            <name>Sathish Kumar A C</name>
+            <email>sath@amazon.com</email>
+            <url>https://www.linkedin.com/in/acsathish</url>
         </developer>
     </developers>
     <inceptionYear>2013</inceptionYear>
@@ -81,7 +96,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.4</version>
+            <version>4.4.9</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -179,9 +194,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs-maven-plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
@@ -280,7 +295,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.93</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -401,7 +416,7 @@
                     <plugin>
                         <groupId>com.bazaarvoice.maven.plugins</groupId>
                         <artifactId>process-exec-maven-plugin</artifactId>
-                        <version>0.4</version>
+                        <version>0.8</version>
                         <executions>
                             <execution>
                                 <id>start-jar-process</id>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,14 +42,12 @@ public class LockItem implements Closeable {
     private final String ownerName;
     private final boolean deleteLockItemOnClose;
     private final boolean isReleased;
-
     private final AtomicLong lookupTime;
     private final StringBuffer recordVersionNumber;
     private final AtomicLong leaseDuration;
     private final Map<String, AttributeValue> additionalAttributes;
 
     private final Optional<SessionMonitor> sessionMonitor;
-
 
     /**
      * Creates a lock item representing a given key. This constructor should
@@ -294,6 +292,15 @@ public class LockItem implements Closeable {
         this.recordVersionNumber.replace(0, recordVersionNumber.length(), recordVersionNumber);
         this.lookupTime.set(lastUpdateOfLock);
         this.leaseDuration.set(leaseDurationToEnsureInMilliseconds);
+    }
+
+    /**
+     * Updates the last updated time of the lock.
+     *
+     * @param lastUpdateOfLock - Time to update the lock with
+     */
+    public void updateLookUpTime(final long lastUpdateOfLock) {
+        this.lookupTime.set(lastUpdateOfLock);
     }
 
     /*

--- a/src/main/java/com/amazonaws/services/dynamodbv2/model/LockCurrentlyUnavailableException.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/model/LockCurrentlyUnavailableException.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * <p>
+ * http://aws.amazon.com/asl/
+ * <p>
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.model;
+
+/**
+ * This is a retry-able exception, that indicates that the lock being requested has already been held by another worker
+ * and has not been released yet and the lease duration has not expired since the lock was last updated by the current
+ * owner.
+ *
+ * The caller can retry acquiring the lock with or without a backoff.
+ *
+ * @author <a href="mailto:sath@amazon.com">Sathish kumar AC</a>
+ */
+public class LockCurrentlyUnavailableException extends RuntimeException {
+
+    private static final long serialVersionUID = 661782974798613851L;
+
+    public LockCurrentlyUnavailableException() {
+    }
+
+    public LockCurrentlyUnavailableException(String message) {
+        super(message);
+    }
+
+    public LockCurrentlyUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+    public LockCurrentlyUnavailableException(String message,
+            Throwable cause) {
+        super(message, cause);
+    }
+
+    public LockCurrentlyUnavailableException(String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AcquireLockOptionsTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AcquireLockOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,10 +14,6 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Optional;
@@ -31,10 +27,14 @@ import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Unit tests for AcquireLockOptions.
  *
- * @author <a href="mailto:amcp@amazon.co.jp">Alexander Patrikalakis</a> 2017-07-13
+ * @author <a href="mailto:amcp@amazon.com">Alexander Patrikalakis</a> 2017-07-13
  */
 @RunWith(MockitoJUnitRunner.class)
 public class AcquireLockOptionsTest {
@@ -63,7 +63,7 @@ public class AcquireLockOptionsTest {
     public void equals_allSame_returnsTrue() {
         AcquireLockOptions left = createLockOptions();
         AcquireLockOptions right = createLockOptions();
-        assertTrue(left.equals(right));
+        assertEquals(left, right);
     }
 
     @Test
@@ -74,13 +74,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -91,13 +94,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -108,13 +114,17 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("squat".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
+            .withShouldSkipBlockingWait(true)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -126,13 +136,16 @@ public class AcquireLockOptionsTest {
                 .withData(ByteBuffer.wrap("data".getBytes()))
                 .withReplaceData(false)
                 .withDeleteLockOnRelease(true)
+                .withAcquireOnlyIfLockAlreadyExists(false)
                 .withRefreshPeriod(1l)
                 .withAdditionalTimeToWaitForLock(1l)
                 .withTimeUnit(TimeUnit.MILLISECONDS)
                 .withAdditionalAttributes(new HashMap<>())
+                .withUpdateExistingLockRecord(false)
+                .withAcquireReleasedLocksConsistently(false)
                 //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
                 .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -143,13 +156,36 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(false)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
+    }
+
+    @Test
+    public void equals_acquireOnlyIfLockAlreadyExistsDifferent_returnsFalse() {
+        AcquireLockOptions left = createLockOptions();
+        AcquireLockOptions right = AcquireLockOptions.builder("partitionKey")
+                .withSortKey("sortKey")
+                .withData(ByteBuffer.wrap("data".getBytes()))
+                .withReplaceData(true)
+                .withDeleteLockOnRelease(true)
+                .withAcquireOnlyIfLockAlreadyExists(true)
+                .withRefreshPeriod(1l)
+                .withAdditionalTimeToWaitForLock(1l)
+                .withTimeUnit(TimeUnit.MILLISECONDS)
+                .withAdditionalAttributes(new HashMap<>())
+                .withUpdateExistingLockRecord(false)
+                .withAcquireReleasedLocksConsistently(false)
+                //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
+                .withRequestMetricCollector(metricCollector).build();
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -160,13 +196,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(2l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -177,13 +216,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(2l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -194,13 +236,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.SECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -211,13 +256,77 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(InternalUtils.toAttributeValues(new Item().withNull("asdf")))
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
+    }
+
+    @Test
+    public void equals_updateExistingLockRecordDifferent_returnsFalse() {
+        AcquireLockOptions left = createLockOptions();
+        AcquireLockOptions right = AcquireLockOptions.builder("partitionKey")
+                .withSortKey("sortKey")
+                .withData(ByteBuffer.wrap("data".getBytes()))
+                .withReplaceData(true)
+                .withDeleteLockOnRelease(true)
+                .withAcquireOnlyIfLockAlreadyExists(false)
+                .withRefreshPeriod(1l)
+                .withAdditionalTimeToWaitForLock(1l)
+                .withTimeUnit(TimeUnit.MILLISECONDS)
+                .withAdditionalAttributes(new HashMap<>())
+                .withUpdateExistingLockRecord(true)
+                .withAcquireReleasedLocksConsistently(false)
+                //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
+                .withRequestMetricCollector(metricCollector).build();
+        assertNotEquals(left, right);
+    }
+
+    @Test
+    public void equals_shouldSkipBlockingWaitDifferent_returnsFalse() {
+        AcquireLockOptions left = createLockOptions();
+        AcquireLockOptions right = AcquireLockOptions.builder("partitionKey")
+                .withSortKey("sortKey")
+                .withData(ByteBuffer.wrap("data".getBytes()))
+                .withReplaceData(true)
+                .withDeleteLockOnRelease(true)
+                .withAcquireOnlyIfLockAlreadyExists(false)
+                .withRefreshPeriod(1l)
+                .withAdditionalTimeToWaitForLock(1l)
+                .withTimeUnit(TimeUnit.MILLISECONDS)
+                .withAdditionalAttributes(new HashMap<>())
+                .withUpdateExistingLockRecord(false)
+                .withShouldSkipBlockingWait(false)
+                .withAcquireReleasedLocksConsistently(false)
+                //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
+                .withRequestMetricCollector(metricCollector).build();
+        assertNotEquals(left, right);
+    }
+
+    @Test
+    public void equals_consistentLockDataDifferent_returnsFalse() {
+        AcquireLockOptions left = createLockOptions();
+        AcquireLockOptions right = AcquireLockOptions.builder("partitionKey")
+                .withSortKey("sortKey")
+                .withData(ByteBuffer.wrap("data".getBytes()))
+                .withReplaceData(true)
+                .withDeleteLockOnRelease(true)
+                .withAcquireOnlyIfLockAlreadyExists(false)
+                .withRefreshPeriod(1l)
+                .withAdditionalTimeToWaitForLock(1l)
+                .withTimeUnit(TimeUnit.MILLISECONDS)
+                .withAdditionalAttributes(new HashMap<>())
+                .withUpdateExistingLockRecord(false)
+                .withAcquireReleasedLocksConsistently(true)
+                //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
+                .withRequestMetricCollector(metricCollector).build();
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -228,13 +337,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             .withSessionMonitor(1L, Optional.empty()) //never equal if session monitor is set
             .withRequestMetricCollector(metricCollector).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -245,13 +357,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) //never equal if session monitor is set
             .withRequestMetricCollector(null).build();
-        assertFalse(left.equals(right));
+        assertNotEquals(left, right);
     }
 
     @Test
@@ -276,11 +391,16 @@ public class AcquireLockOptionsTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withReplaceData(true)
             .withDeleteLockOnRelease(true)
+            .withAcquireOnlyIfLockAlreadyExists(false)
             .withRefreshPeriod(1l)
             .withAdditionalTimeToWaitForLock(1l)
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withAdditionalAttributes(new HashMap<>())
+            .withUpdateExistingLockRecord(false)
+            .withShouldSkipBlockingWait(true)
+            .withAcquireReleasedLocksConsistently(false)
             //.withSessionMonitor(1L, Optional.empty()) never equal if session monitor is set
             .withRequestMetricCollector(metricCollector);
+
     }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,16 +14,6 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
-
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
@@ -35,11 +25,13 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import javax.swing.text.html.Option;
-
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -47,22 +39,45 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.ItemUtils;
 import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.LockCurrentlyUnavailableException;
 import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
 import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.dynamodbv2.model.TableStatus;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
+
+import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient
+        .PK_EXISTS_AND_RVN_IS_THE_SAME_AND_IS_RELEASED_CONDITION;
+import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient.RVN_VALUE_EXPRESSION_VARIABLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Unit tests for AmazonDynamoDBLockClient.
  *
- * @author <a href="mailto:amcp@amazon.co.jp">Alexander Patrikalakis</a> 2017-07-13
+ * @author <a href="mailto:amcp@amazon.com">Alexander Patrikalakis</a> 2017-07-13
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({AmazonDynamoDBLockClient.class, AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder.class, AmazonDynamoDBLockClientTest.class})
@@ -148,6 +163,15 @@ public class AmazonDynamoDBLockClientTest {
         client.acquireLock(AcquireLockOptions.builder("asdf").build());
     }
 
+    @Test(expected = LockNotGrantedException.class)
+    public void acquireLock_whenProvisionedThroughputExceeds_throwLockNotGrantedException() throws InterruptedException {
+        setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult());
+        when(dynamodb.putItem(any())).thenThrow(new ProvisionedThroughputExceededException("Provisioned Throughput for the table exceeded"));
+        client.acquireLock(AcquireLockOptions.builder("asdf").build());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void acquireLock_whenLockAlreadyExists_throwIllegalArgumentException() throws InterruptedException {
         setOwnerNameToUuid();
@@ -157,6 +181,44 @@ public class AmazonDynamoDBLockClientTest {
         client.acquireLock(AcquireLockOptions.builder("asdf")
             .withSortKey("sort")
             .withAdditionalAttributes(additionalAttributes).build());
+    }
+
+    @Test(expected = LockNotGrantedException.class)
+    public void acquireLock_whenLockDoesNotExist_andWhenAcquireOnlyIfLockAlreadyExistsTrue_throwLockNotGrantedException() throws InterruptedException {
+        setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult());
+        client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireOnlyIfLockAlreadyExists(true).build());
+    }
+
+    @Test(expected = LockNotGrantedException.class)
+    public void acquireLock_withAcquireOnlyIfLockAlreadyExistsTrue_releasedLockConditionalCheckFailure() throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        doAnswer((InvocationOnMock invocation) -> new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                            .withString("customer", "customer1")
+                            .withString("ownerName", "foobar")
+                            .withString("recordVersionNumber", uuid.toString())
+                            .withString("leaseDuration", "1")
+                            .withBoolean("isReleased", true))))
+                .when(dynamodb).getItem(any());
+        when(dynamodb.putItem(any())).thenThrow(new ConditionalCheckFailedException("item existed"));
+        client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireOnlyIfLockAlreadyExists(true).build());
+    }
+
+    @Test
+    public void acquireLock_withAcquireOnlyIfLockAlreadyExists_releasedLockGetsCreated() throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", uuid.toString())
+                .withString("leaseDuration", "1")
+                .withBoolean("isReleased", true))));
+        LockItem item = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireOnlyIfLockAlreadyExists(true).build());
+        assertNotNull(item);
+        assertEquals("asdf", item.getPartitionKey());
     }
 
     @Test
@@ -184,6 +246,124 @@ public class AmazonDynamoDBLockClientTest {
             .withTimeUnit(TimeUnit.MILLISECONDS)
             .withDeleteLockOnRelease(false).build());
         assertNotNull(item);
+    }
+
+    @Test(expected = LockNotGrantedException.class)
+    public void acquireLock_withConsistentLockDataTrue_releasedLockConditionalCheckFailure() throws InterruptedException {
+    UUID uuid = setOwnerNameToUuid();
+    AmazonDynamoDBLockClient client = getLockClient();
+
+        doAnswer((InvocationOnMock invocation) -> new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", uuid.toString())
+                .withString("leaseDuration", "1")
+                .withBoolean("isReleased", true))))
+                .when(dynamodb).getItem(any());
+        when(dynamodb.putItem(any())).thenThrow(new ConditionalCheckFailedException("RVN constraint failed"));
+        client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireReleasedLocksConsistently(true).build());
+    }
+
+    @Test
+    public void acquireLock_withNotUpdateRecordAndConsistentLockDataTrue_releasedLockGetsCreated() throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", "a specific rvn")
+                .withString("leaseDuration", "1")
+                .withBoolean("isReleased", true))));
+        LockItem item = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireReleasedLocksConsistently(true).withUpdateExistingLockRecord
+                (false).build());
+        assertNotNull(item);
+        assertEquals("asdf", item.getPartitionKey());
+        ArgumentCaptor<PutItemRequest> putItemCaptor = ArgumentCaptor.forClass(PutItemRequest.class);
+        verify(dynamodb).putItem(putItemCaptor.capture());
+        PutItemRequest putItemRequest = putItemCaptor.getValue();
+        assertEquals(PK_EXISTS_AND_RVN_IS_THE_SAME_AND_IS_RELEASED_CONDITION, putItemRequest.getConditionExpression());
+        assertEquals("a specific rvn", putItemRequest.getExpressionAttributeValues().get(RVN_VALUE_EXPRESSION_VARIABLE).getS());
+    }
+
+    @Test
+    public void acquireLock_withUpdateRecordAndConsistentLockDataTrue_releasedLockGetsCreated() throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", "a specific rvn")
+                .withString("leaseDuration", "1")
+                .withBoolean("isReleased", true))));
+        LockItem item = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireReleasedLocksConsistently(true).withUpdateExistingLockRecord
+                (true).build());
+        assertNotNull(item);
+        assertEquals("asdf", item.getPartitionKey());
+        ArgumentCaptor<UpdateItemRequest> updateItemCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(dynamodb).updateItem(updateItemCaptor.capture());
+        UpdateItemRequest updateItemRequest = updateItemCaptor.getValue();
+        assertEquals(PK_EXISTS_AND_RVN_IS_THE_SAME_AND_IS_RELEASED_CONDITION, updateItemRequest.getConditionExpression());
+        assertEquals("a specific rvn", updateItemRequest.getExpressionAttributeValues().get(RVN_VALUE_EXPRESSION_VARIABLE).getS());
+    }
+
+    /*
+     * Test case that tests that the lock was successfully acquired when the lock does not exist in the table.
+     */
+    @Test
+    public void acquireLock_whenLockNotExists_andSkipBlockingWaitIsTurnedOn()
+        throws InterruptedException {
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any())).thenReturn(new GetItemResult());
+        LockItem lockItem = client.acquireLock(AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build());
+        Assert.assertNotNull("Failed to get lock item, when the lock is not present in the db", lockItem);
+    }
+
+    /*
+     * Test case that tests that the lock was successfully acquired when the lock exist in the table and the lock has
+     * past the lease duration. This is for cases where the first owner(host) who acquired the lock abruptly died
+     * without releasing the lock before the expiry of the lease duration.
+     */
+    @Test
+    public void acquireLock_whenLockExistsAndIsExpired_andSkipBlockingWaitIsTurnedOn()
+        throws InterruptedException {
+        AmazonDynamoDBLockClient client = getLockClient();
+        UUID uuid = setOwnerNameToUuid();
+        when(dynamodb.getItem(any()))
+            .thenReturn(new GetItemResult().withItem(ItemUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", uuid.toString())
+                .withString("leaseDuration", "1")
+                .withBoolean("isReleased", true)
+                )))
+            .thenReturn(new GetItemResult());
+        LockItem lockItem = client.acquireLock(AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build());
+        Assert.assertNotNull("Failed to get lock item, when the lock is not present in the db", lockItem);
+    }
+    /*
+     * Test case for the scenario, where the lock is being held by the first owner and the lock duration has not past the lease duration.
+     * In this case, We should expect a LockAlreadyOwnedException when shouldSkipBlockingWait is set.
+     */
+    @Test(expected = LockCurrentlyUnavailableException.class)
+    public void acquireLock_whenLockAlreadyExistsAndIsNotReleased_andSkipBlockingWait_throwsAlreadyOwnedException()
+        throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(any()))
+            .thenReturn(new GetItemResult().withItem(InternalUtils.toAttributeValues(new Item()
+                .withString("customer", "customer1")
+                .withString("ownerName", "foobar")
+                .withString("recordVersionNumber", uuid.toString())
+                .withString("leaseDuration", "10001")
+                )))
+            .thenReturn(new GetItemResult());
+        client.acquireLock(AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -242,6 +422,59 @@ public class AmazonDynamoDBLockClientTest {
             .withData(ByteBuffer.wrap("data".getBytes()))
             .withRequestMetricCollector(RequestMetricCollector.NONE)
             .build());
+    }
+
+    @Test
+    public void sendHeartbeat_whenServiceUnavailable_andHoldLockOnServiceUnavailableFalse_thenDoNotUpdateLookupTime() throws LockNotGrantedException {
+        AmazonServiceException serviceUnavailableException = new AmazonServiceException("Service Unavailable.");
+        serviceUnavailableException.setStatusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
+        when(dynamodb.updateItem(any())).thenThrow(serviceUnavailableException);
+
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(getLockClientBuilder(null).withHoldLockOnServiceUnavailable(false).build());
+
+        long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
+        LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
+                false, uuid.toString(), 10000L, lastUpdatedTimeInMilliseconds,
+                "rvn", false, Optional.empty(), null);
+
+        AmazonServiceException amazonServiceException = null;
+        try {
+            client.sendHeartbeat(SendHeartbeatOptions.builder(item).build());
+        } catch (AmazonServiceException e) {
+            amazonServiceException = e;
+        }
+
+        assertEquals(serviceUnavailableException, amazonServiceException);
+        assertEquals(lastUpdatedTimeInMilliseconds, item.getLookupTime());
+    }
+
+    @Test
+    public void sendHeartbeat_whenServiceUnavailable_andHoldLockOnServiceUnavailableTrue_thenUpdateLookupTimeUsingUpdateLookUpTimeMethod() throws LockNotGrantedException, InterruptedException {
+        AmazonServiceException serviceUnavailableException = new AmazonServiceException("Service Unavailable.");
+        serviceUnavailableException.setStatusCode(HttpStatus.SC_SERVICE_UNAVAILABLE);
+        when(dynamodb.updateItem(any())).thenThrow(serviceUnavailableException);
+
+        UUID uuid = setOwnerNameToUuid();
+        long leaseDuration = 10000L;
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(getLockClientBuilder(null)
+                .withLeaseDuration(leaseDuration).withHoldLockOnServiceUnavailable(true).build());
+
+        String recordVersionNumber = "rvn";
+        long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
+        LockItem lockItem = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
+                false, uuid.toString(), leaseDuration, lastUpdatedTimeInMilliseconds,
+                recordVersionNumber, false, Optional.empty(), null);
+
+        // Setting up a spy mock to inspect the method on lockItem object created above
+        LockItem lockItemSpy = PowerMockito.spy(lockItem);
+
+        Thread.sleep(1L); // This is to make sure that the lookup time has a higher value
+        client.sendHeartbeat(SendHeartbeatOptions.builder(lockItemSpy).build());
+
+        assertTrue(lockItemSpy.getLookupTime() > lastUpdatedTimeInMilliseconds);
+        verify(lockItemSpy, times(1)).updateLookUpTime(anyLong());
+        verify(lockItemSpy, times(0)).updateRecordVersionNumber(anyString(), anyLong(), anyLong());
     }
 
     private AmazonDynamoDBLockClient getLockClient() {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/ConsistentLockDataStressTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/ConsistentLockDataStressTest.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * <p>
+ * http://aws.amazon.com/asl/
+ * <p>
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Used to verify consistent lock data functionality in multi-threaded lock environment
+ */
+public class ConsistentLockDataStressTest extends InMemoryLockClientTester {
+    private static final Log logger = LogFactory.getLog(ConsistentLockDataStressTest.class);
+
+    @Test
+    public void consistentDataUsingUpdateLockRecord() throws InterruptedException, IOException, ExecutionException {
+        final int numOfThreads = 50;
+        final int maxWorkDoneMillis = 100;
+        final int numRepetitions = 10;
+
+        final LockItem initalLock = lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder(
+                "consistentDataUsingUpdateLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(true)
+                .withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(false).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+
+        lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(initalLock).withDeleteLock(false).withData(putLockData(0))
+                .withBestEffort(false).build());
+
+        final Runnable runnable = () -> {
+            Optional<LockItem> lockItem = Optional.empty();
+            Integer count = 0;
+            try {
+                lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder("consistentDataUsingUpdateLockRecordKey")
+                        .withAcquireOnlyIfLockAlreadyExists(true).withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(
+                                true).withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(false)
+                        .withRefreshPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).build());
+                assertNotEquals(Optional.empty(), lockItem);
+                count = getLockData(lockItem.get()) + 1;
+                Thread.sleep(getRandomNumberInRange(1, maxWorkDoneMillis));
+            } catch (final InterruptedException e) {
+                fail("Should not get interrupted!");
+            } finally {
+                if (lockItem.isPresent()) {
+                    lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(lockItem.get()).withDeleteLock(false).withData(
+                            putLockData(count)).withBestEffort(false).build());
+                }
+            }
+        };
+
+        assertConcurrent("consistentDataUsingUpdateLockRecord", Collections.nCopies(numOfThreads, runnable), 600, numRepetitions);
+
+        final Optional<LockItem> lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder(
+                "consistentDataUsingUpdateLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(true)
+                .withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(true).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+        assertNotEquals(Optional.empty(), lockItem);
+        assertEquals(numOfThreads*numRepetitions, getLockData(lockItem.get()).intValue());
+        lockItem.get().close();
+    }
+
+    @Test
+    public void notConsistentLockDataUsingUpdateLockRecord() throws InterruptedException, IOException, ExecutionException {
+        final int numOfThreads = 50;
+        final int maxWorkDoneMillis = 100;
+        final int numRepetitions = 10;
+
+        final LockItem initalLock = lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder(
+                "notConsistentLockDataUsingUpdateLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(false)
+                .withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(false).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+
+        lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(initalLock).withDeleteLock(false).withData(putLockData(0))
+                .withBestEffort(false).build());
+
+        final Runnable runnable = () -> {
+            Optional<LockItem> lockItem = Optional.empty();
+            Integer count = 0;
+            try {
+                lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder("notConsistentLockDataUsingUpdateLockRecordKey")
+                        .withAcquireOnlyIfLockAlreadyExists(true).withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(
+                                false).withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(false)
+                        .withRefreshPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).build());
+                assertNotEquals(Optional.empty(), lockItem);
+                count = getLockData(lockItem.get()) + 1;
+                Thread.sleep(getRandomNumberInRange(1, maxWorkDoneMillis));
+            } catch (final InterruptedException e) {
+                fail("Should not get interrupted!");
+            } finally {
+                if (lockItem.isPresent()) {
+                    lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(lockItem.get()).withDeleteLock(false).withData(
+                            putLockData(count)).withBestEffort(false).build());
+                }
+            }
+        };
+
+        assertConcurrent("notConsistentLockDataUsingUpdateLockRecord", Collections.nCopies(numOfThreads, runnable), 600, numRepetitions);
+
+        final Optional<LockItem> lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder(
+                "notConsistentLockDataUsingUpdateLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(false)
+                .withReplaceData(false).withUpdateExistingLockRecord(true).withDeleteLockOnRelease(true).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+        assertNotEquals(Optional.empty(), lockItem);
+        assertNotEquals(numOfThreads*numRepetitions, getLockData(lockItem.get()).intValue());
+        lockItem.get().close();
+    }
+
+    @Test
+    public void consistentDataUsingPutLockRecord() throws InterruptedException, IOException, ExecutionException {
+        final int numOfThreads = 50;
+        final int maxWorkDoneMillis = 100;
+        final int numRepetitions = 10;
+
+        final LockItem initalLock = lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("consistentDataUsingPutLockRecordKey")
+                .withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(true).withReplaceData(false)
+                .withUpdateExistingLockRecord(false).withDeleteLockOnRelease(false).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+
+        lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(initalLock).withDeleteLock(false).withData(putLockData(0))
+                .withBestEffort(false).build());
+
+        final Runnable runnable = () -> {
+            Optional<LockItem> lockItem = Optional.empty();
+            Integer count = 0;
+            try {
+                lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder("consistentDataUsingPutLockRecordKey")
+                        .withAcquireOnlyIfLockAlreadyExists(true).withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(
+                                true).withReplaceData(false).withUpdateExistingLockRecord(false).withDeleteLockOnRelease(false)
+                        .withRefreshPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).build());
+                assertNotEquals(Optional.empty(), lockItem);
+                count = getLockData(lockItem.get()) + 1;
+                Thread.sleep(getRandomNumberInRange(1, maxWorkDoneMillis));
+            } catch (final InterruptedException e) {
+                fail("Should not get interrupted!");
+            } finally {
+                if (lockItem.isPresent()) {
+                    lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(lockItem.get()).withDeleteLock(false).withData(
+                            putLockData(count)).withBestEffort(false).build());
+                }
+            }
+        };
+
+        assertConcurrent("consistentDataUsingPutLockRecord", Collections.nCopies(numOfThreads, runnable), 600, numRepetitions);
+
+        final Optional<LockItem> lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder(
+                "consistentDataUsingPutLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(true)
+                .withReplaceData(false).withUpdateExistingLockRecord(false).withDeleteLockOnRelease(true).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+        assertNotEquals(Optional.empty(), lockItem);
+        assertEquals(numOfThreads*numRepetitions, getLockData(lockItem.get()).intValue());
+        lockItem.get().close();
+    }
+
+    @Test
+    public void notConsistentLockDataUsingPutLockRecord() throws InterruptedException, IOException, ExecutionException {
+        final int numOfThreads = 50;
+        final int maxWorkDoneMillis = 100;
+        final int numRepetitions = 10;
+
+        final LockItem initalLock = lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("notConsistentLockDataUsingPutLockRecordKey")
+                .withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(false).withReplaceData(false)
+                .withUpdateExistingLockRecord(false).withDeleteLockOnRelease(false).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+
+        lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(initalLock).withDeleteLock(false).withData(putLockData(0))
+                .withBestEffort(false).build());
+
+        final Runnable runnable = () -> {
+            Optional<LockItem> lockItem = Optional.empty();
+            Integer count = 0;
+            try {
+                lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder("notConsistentLockDataUsingPutLockRecordKey")
+                        .withAcquireOnlyIfLockAlreadyExists(true).withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(
+                                false).withReplaceData(false).withUpdateExistingLockRecord(false).withDeleteLockOnRelease(false)
+                        .withRefreshPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).build());
+                assertNotEquals(Optional.empty(), lockItem);
+                count = getLockData(lockItem.get()) + 1;
+                Thread.sleep(getRandomNumberInRange(1, maxWorkDoneMillis));
+            } catch (final InterruptedException e) {
+                fail("Should not get interrupted!");
+            } finally {
+                if (lockItem.isPresent()) {
+                    lockClientWithHeartbeating.releaseLock(ReleaseLockOptions.builder(lockItem.get()).withDeleteLock(false).withData(
+                            putLockData(count)).withBestEffort(false).build());
+                }
+            }
+        };
+
+        assertConcurrent("notConsistentLockDataUsingPutLockRecord", Collections.nCopies(numOfThreads, runnable), 600, numRepetitions);
+
+        final Optional<LockItem> lockItem = lockClientWithHeartbeating.tryAcquireLock(AcquireLockOptions.builder(
+                "notConsistentLockDataUsingPutLockRecordKey").withAdditionalTimeToWaitForLock(Long.MAX_VALUE / 2).withAcquireReleasedLocksConsistently(false)
+                .withReplaceData(false).withUpdateExistingLockRecord(false).withDeleteLockOnRelease(true).withRefreshPeriod(10L)
+                .withTimeUnit(TimeUnit.MILLISECONDS).build());
+        assertNotEquals(Optional.empty(), lockItem);
+        assertNotEquals(numOfThreads*numRepetitions, getLockData(lockItem.get()).intValue());
+        lockItem.get().close();
+    }
+
+    private static Integer getLockData(final LockItem lockItem) {
+        return Integer.valueOf(new String(lockItem.getData().orElse(ByteBuffer.wrap("0".getBytes())).array()));
+    }
+
+    private static ByteBuffer putLockData(final Integer count) {
+        return ByteBuffer.wrap(String.valueOf(count).getBytes());
+    }
+
+    private static void assertConcurrent(final String message, final Collection<? extends Runnable> runnables, final int maxTimeoutSeconds,
+                                         final int numOfRepetitions) throws InterruptedException {
+        assertTrue(message + " Number of repetitions should be greater than 0", numOfRepetitions > 0);
+        final int numThreads = runnables.size();
+        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(() -> {
+                    allExecutorThreadsReady.countDown();
+                    try {
+                        afterInitBlocker.await();
+                        repeat(submittedTestRunnable, numOfRepetitions);
+                    } catch (final Throwable e) {
+                        exceptions.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+            }
+            // wait until all threads are ready
+            assertTrue(
+                    message + " Timeout initializing threads! Perform long lasting initializations before passing runnables to " +
+                            "assertConcurrent",
+                    allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS));
+            // start all test runners
+            afterInitBlocker.countDown();
+            assertTrue(message + " Timeout! More than" + maxTimeoutSeconds + "seconds", allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+        } finally {
+            threadPool.shutdownNow();
+        }
+
+        if (!exceptions.isEmpty()) {
+            for (final Throwable e : exceptions) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+        assertTrue(message + " failed with exception(s)" + exceptions, exceptions.isEmpty());
+    }
+
+    private static void repeat(final Runnable action, final int numOfRepetitions) {
+        for (int i = 0; i < numOfRepetitions; i++) {
+            action.run();
+        }
+    }
+
+    private static int getRandomNumberInRange(final int min, final int max) {
+        final Random r = new Random();
+        return r.ints(min, (max + 1)).limit(1).findFirst().getAsInt();
+    }
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/InMemoryLockClientTester.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/InMemoryLockClientTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -27,13 +28,15 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
+
 /**
  * Base class for lock client tests. Sets up in-memory version of DynamoDB.
  *
  * @author <a href="mailto:slutsker@amazon.com">Sasha Slutsker</a>
- * @author <a href="mailto:amcp@amazon.co.jp">Alexander Patrikalakis</a>
+ * @author <a href="mailto:amcp@amazon.com">Alexander Patrikalakis</a>
  */
-public class InMemoryLockClientTester {
+public abstract class InMemoryLockClientTester {
     protected static final String LOCALHOST = "mars";
     protected static final String INTEGRATION_TESTER = "integrationTester";
     protected static final SecureRandom SECURE_RANDOM;
@@ -48,15 +51,78 @@ public class InMemoryLockClientTester {
     protected static final long SHORT_LEASE_DUR = 60L; //60 milliseconds
 
     protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_TEST_KEY_1 = AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).build();
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_TEST_KEY_1_SORT_1 = AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).build();
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_TEST_KEY_1_SORT_2 = AcquireLockOptions.builder("testKey1").withSortKey("2").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_FALSE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAcquireOnlyIfLockAlreadyExists
+                    (true).withReplaceData(false).withUpdateExistingLockRecord(false).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_FALSE_CONSISTENT_DATA_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAcquireOnlyIfLockAlreadyExists
+                    (true).withReplaceData(false).withUpdateExistingLockRecord(false).withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_FALSE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes()))
+                    .withAcquireOnlyIfLockAlreadyExists(true).withReplaceData(false).withUpdateExistingLockRecord(false).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_FALSE_CONSISTENT_DATA_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes()))
+                    .withAcquireOnlyIfLockAlreadyExists(true).withReplaceData(false).withUpdateExistingLockRecord(false)
+                    .withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAcquireOnlyIfLockAlreadyExists(true)
+                    .withReplaceData(false).withUpdateExistingLockRecord(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_TRUE_CONSISTENT_DATA_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAcquireOnlyIfLockAlreadyExists(true)
+                    .withReplaceData(false).withUpdateExistingLockRecord(true).withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes()))
+                    .withAcquireOnlyIfLockAlreadyExists(true).withReplaceData(false).withUpdateExistingLockRecord(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_ONLY_IF_LOCK_EXIST_UPDATE_TRUE_CONSISTENT_DATA_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAcquireOnlyIfLockAlreadyExists(true)
+                    .withReplaceData(false).withUpdateExistingLockRecord(true).withAcquireReleasedLocksConsistently(true).build();
 
     protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE =
         AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_CONSISTENT_DATA_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false)
+                    .withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_CONSISTENT_DATA_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false)
+                    .withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_UPDATE_EXISTING_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).withUpdateExistingLockRecord(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_UPDATE_EXISTING_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).withUpdateExistingLockRecord(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_UPDATE_EXISTING_TRUE_CONSISTENT_DATA_TRUE =
+            AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).withUpdateExistingLockRecord(true)
+                    .withAcquireReleasedLocksConsistently(true).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_REPLACE_DATA_FALSE_UPDATE_EXISTING_TRUE_CONSISTENT_DATA_TRUE_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withReplaceData(false).withUpdateExistingLockRecord(true).withAcquireReleasedLocksConsistently(true).build();
 
     protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_TEST_KEY_2 = AcquireLockOptions.builder("testKey2").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).build();
 
     protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_WITH_NO_WAIT =
         AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAdditionalTimeToWaitForLock(0L).withRefreshPeriod(0L)
             .withTimeUnit(TimeUnit.SECONDS).build();
+
+    protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_WITH_NO_WAIT_SORT_1 =
+            AcquireLockOptions.builder("testKey1").withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes()))
+                    .withAdditionalTimeToWaitForLock(0L).withRefreshPeriod(0L).withTimeUnit(TimeUnit.SECONDS).build();
 
     protected static final AcquireLockOptions ACQUIRE_LOCK_OPTIONS_5_SECONDS =
         AcquireLockOptions.builder("testKey1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withAdditionalTimeToWaitForLock(5L).withRefreshPeriod(1L)
@@ -69,7 +135,11 @@ public class InMemoryLockClientTester {
     protected AmazonDynamoDB dynamoDBMock;
     protected AmazonDynamoDBLockClient lockClient;
     protected AmazonDynamoDBLockClient lockClientWithHeartbeating;
+    protected AmazonDynamoDBLockClient lockClientForRangeKeyTable;
+    protected AmazonDynamoDBLockClient lockClientWithHeartbeatingForRangeKeyTable;
     protected AmazonDynamoDBLockClient shortLeaseLockClient;
+    protected AmazonDynamoDBLockClient shortLeaseLockClientWithHeartbeating;
+    protected AmazonDynamoDBLockClient shortLeaseLockClientForRangeKeyTable;
     protected AmazonDynamoDBLockClient lockClientNoTable;
     protected AmazonDynamoDBLockClientOptions lockClient1Options;
 
@@ -77,10 +147,15 @@ public class InMemoryLockClientTester {
     public void setUp() {
         final AWSCredentials credentials = new BasicAWSCredentials(TABLE_NAME, "");
         final String endpoint = System.getProperty("dynamodb-local.endpoint");
+        if (endpoint == null) {
+            throw new IllegalStateException("The JVM was not launched with the dynamodb-local.endpoint system property set");
+        }
+        if (endpoint.isEmpty()) {
+            throw new IllegalStateException("The JVM was not launched with the dynamodb-local.endpoint system property set to a non-empty string");
+        }
 
-        this.dynamoDBMock =
-            AmazonDynamoDBClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withEndpointConfiguration(new EndpointConfiguration(endpoint, ""))
-                .build();
+        this.dynamoDBMock = safelySpyDDB(AmazonDynamoDBClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withEndpointConfiguration(new EndpointConfiguration(endpoint, "")).build());
 
         AmazonDynamoDBLockClient.createLockTableInDynamoDB(
             CreateDynamoDBTableOptions.builder(this.dynamoDBMock, new ProvisionedThroughput().withReadCapacityUnits(10L).withWriteCapacityUnits(10L), TABLE_NAME).build());
@@ -91,16 +166,33 @@ public class InMemoryLockClientTester {
         this.lockClient1Options =
             new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(3L).withHeartbeatPeriod(1L)
                 .withTimeUnit(TimeUnit.SECONDS).withCreateHeartbeatBackgroundThread(false).build();
-        this.lockClient = new AmazonDynamoDBLockClient(this.lockClient1Options);
-        this.lockClientWithHeartbeating = new AmazonDynamoDBLockClient(
+        this.lockClient = Mockito.spy(new AmazonDynamoDBLockClient(this.lockClient1Options));
+        this.lockClientWithHeartbeating = Mockito.spy(new AmazonDynamoDBLockClient(
             new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(3L).withHeartbeatPeriod(1L)
-                .withTimeUnit(TimeUnit.SECONDS).withCreateHeartbeatBackgroundThread(true).build());
-        this.lockClientNoTable = new AmazonDynamoDBLockClient(
+                .withTimeUnit(TimeUnit.SECONDS).withCreateHeartbeatBackgroundThread(true).build()));
+        this.lockClientNoTable = Mockito.spy(new AmazonDynamoDBLockClient(
             new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, "doesNotExist", INTEGRATION_TESTER).withLeaseDuration(3L).withHeartbeatPeriod(1L)
-                .withTimeUnit(TimeUnit.SECONDS).withCreateHeartbeatBackgroundThread(false).build());
-        this.shortLeaseLockClient = new AmazonDynamoDBLockClient(
+                .withTimeUnit(TimeUnit.SECONDS).withCreateHeartbeatBackgroundThread(false).build()));
+        this.shortLeaseLockClient = Mockito.spy(new AmazonDynamoDBLockClient(
             new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(SHORT_LEASE_DUR)
-                .withHeartbeatPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).withCreateHeartbeatBackgroundThread(false).build());
+                .withHeartbeatPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).withCreateHeartbeatBackgroundThread(false).build()));
+        this.shortLeaseLockClientWithHeartbeating = Mockito.spy(new AmazonDynamoDBLockClient(
+                new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(SHORT_LEASE_DUR)
+                        .withHeartbeatPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).withCreateHeartbeatBackgroundThread(true).build()));
+        this.lockClientForRangeKeyTable = Mockito.spy(new AmazonDynamoDBLockClient(
+                new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, RANGE_KEY_TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(3L).withHeartbeatPeriod(1L)
+                        .withTimeUnit(TimeUnit.SECONDS).withSortKeyName("rangeKey").withCreateHeartbeatBackgroundThread(false).build()));
+        this.lockClientWithHeartbeatingForRangeKeyTable = Mockito.spy(new AmazonDynamoDBLockClient(
+                new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, RANGE_KEY_TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(3L).withHeartbeatPeriod(1L)
+                        .withTimeUnit(TimeUnit.SECONDS).withSortKeyName("rangeKey").withCreateHeartbeatBackgroundThread(true).build()));
+        this.shortLeaseLockClientForRangeKeyTable = Mockito.spy(new AmazonDynamoDBLockClient(
+                new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, RANGE_KEY_TABLE_NAME, INTEGRATION_TESTER).withLeaseDuration(SHORT_LEASE_DUR)
+                        .withHeartbeatPeriod(10L).withTimeUnit(TimeUnit.MILLISECONDS).withSortKeyName("rangeKey").withCreateHeartbeatBackgroundThread(false).build()));
+    }
+
+    public AmazonDynamoDB safelySpyDDB(final AmazonDynamoDB dynamoDB) {
+        //Replaces Mockito.spy(this.dynamoDBMock) and works for proxies as well (i.e. dynamodb local embedded)
+        return Mockito.mock(AmazonDynamoDB.class, delegatesTo(dynamoDB));
     }
 
     @After

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -35,7 +36,7 @@ import com.amazonaws.services.dynamodbv2.model.SessionMonitorNotSetException;
 /**
  * LockItem unit tests.
  *
- * @author <a href="mailto:amcp@amazon.co.jp">Alexander Patrikalakis</a> 2017-07-13
+ * @author <a href="mailto:amcp@amazon.com">Alexander Patrikalakis</a> 2017-07-13
  */
 @RunWith(MockitoJUnitRunner.class)
 public class LockItemTest {
@@ -167,6 +168,17 @@ public class LockItemTest {
             false, //released
             Optional.empty(), //session monitor
             new HashMap<>()).hasCallback();
+    }
+
+    @Test
+    public void updateLookUpTime_whenLookUpTimeIsUpdated_thenGetLookUpTimeReturnsTheUpdatedTime() {
+        LockItem lockItem = createLockItem(lockClient);
+        assertEquals(1000, lockItem.getLookupTime());
+
+        //update the look up time
+        lockItem.updateLookUpTime(2000);
+
+        assertEquals(2000, lockItem.getLookupTime());
     }
 
     static LockItem createLockItem(AmazonDynamoDBLockClient lockClient) {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/model/ExceptionTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/model/ExceptionTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * <p>
  * Licensed under the Amazon Software License (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.junit.Test;
 /**
  * Unit tests for Exceptions defined in this class.
  *
- * @author <a href="mailto:amcp@amazon.co.jp">Alexander Patrikalakis</a> 2017-07-13
+ * @author <a href="mailto:amcp@amazon.com">Alexander Patrikalakis</a> 2017-07-13
  */
 public class ExceptionTests {
     @Test
@@ -36,5 +36,41 @@ public class ExceptionTests {
     public void constructorNoArgs_LockNotGrantedException() {
         LockNotGrantedException e = new LockNotGrantedException();
         assertNull(e.getCause());
+    }
+
+    @Test
+    public void constructor_LockCurrentlyUnavailableException() {
+        LockCurrentlyUnavailableException e = new LockCurrentlyUnavailableException();
+        assertNull(e.getCause());
+    }
+
+    @Test
+    public void constructorWithMessageAndCause_LockCurrentlyUnavailableException() {
+        final IllegalArgumentException iae = new IllegalArgumentException();
+        LockCurrentlyUnavailableException e = new LockCurrentlyUnavailableException("message", iae);
+        assertEquals(iae, e.getCause());
+        assertEquals("message", e.getMessage());
+    }
+
+    @Test
+    public void constructorWithCause_LockCurrentlyUnavailableException() {
+        final IllegalArgumentException iae = new IllegalArgumentException();
+        LockCurrentlyUnavailableException e = new LockCurrentlyUnavailableException(iae);
+        assertEquals(iae, e.getCause());
+    }
+
+    @Test
+    public void constructorWithMessage_LockCurrentlyUnavailableException() {
+        final IllegalArgumentException iae = new IllegalArgumentException();
+        LockCurrentlyUnavailableException e = new LockCurrentlyUnavailableException("message");
+        assertEquals("message", e.getMessage());
+    }
+
+    @Test
+    public void constructorWithMessageAndCauseAndSuppressionAndStackTrace_LockCurrentlyUnavailableException() {
+        final IllegalArgumentException iae = new IllegalArgumentException();
+        LockCurrentlyUnavailableException e = new LockCurrentlyUnavailableException("message", iae, false, false);
+        assertEquals(iae, e.getCause());
+        assertEquals("message", e.getMessage());
     }
 }


### PR DESCRIPTION
*Issue #, if available:* Fixes #2, #8, and #12 

*Description of changes:*
- AcquireLockOption "acquireOnlyIfLockAlreadyExists" added to ensure that no new lock items are created
- AcquireLockOption "updateExistingLockRecord" added to use UpdateItem instead of PutItem to prevent concurrent changes to unrelated attributes in the item from being overwritten.
- AcquireLockOption "holdLockOnServiceUnavailable" added to enable lock clients to continue holding a lock after the service throws an ISE (5XX error)
- Allows the use of existing tables by configurable attribute names.
- Relaxes null constraints on items that were not used with the lock client before.
- Updates the AWS SDK to 1.11.475
- Updates other dependencies in the build toolchain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
