### PR TITLE
Check for sortkey values

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -898,7 +898,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     private Map<String, AttributeValue> getKeys(String partitionKey, Optional<String> sortKey) {
         final Map<String, AttributeValue> key = new HashMap<>();
         key.put(this.partitionKeyName, AttributeValue.builder().s(partitionKey).build());
-        if (sortKey.isPresent()) {
+        if (sortKey.isPresent() && this.sortKeyName.isPresent()) {
             key.put(this.sortKeyName.get(), AttributeValue.builder().s(sortKey.get()).build());
         }
         return key;
@@ -1221,7 +1221,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     private GetItemResponse readFromDynamoDB(final String key, final Optional<String> sortKey) {
         final Map<String, AttributeValue> dynamoDBKey = new HashMap<>();
         dynamoDBKey.put(this.partitionKeyName, AttributeValue.builder().s(key).build());
-        if (this.sortKeyName.isPresent()) {
+        if (this.sortKeyName.isPresent() && sortKey.isPresent()) {
             dynamoDBKey.put(this.sortKeyName.get(), AttributeValue.builder().s(sortKey.get()).build());
         }
         final GetItemRequest getItemRequest = GetItemRequest.builder().tableName(tableName).key(dynamoDBKey)


### PR DESCRIPTION
Check for the sort key values, otherwise it crash at runtime

Signed-off-by: serngawy <m.elserngawy@gmail.com>

*Issue #, if available:*

*Description of changes:*
Establish the dynamoDbLock client with a sort key then create a lockItem without sortkey crash at run-time. Checking for sortKey option prevent this behaviour. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
